### PR TITLE
fix(tailwindcss): Add required mark config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,31 @@ However, if you install the gem, you will get the latest updates and improvement
 
 ## Usage
 
-### Install Tailwind CSS initializer
+### Install Tailwind CSS files
 
 ```bash
 bin/rails generate simple_form:theme:tailwind install
 ```
 
-### Install Bulma CSS initializer
+After running this generator, you will see the `config/initializers/simple_form_tailwindcss.rb` file.
+This file adds the Tailwind CSS styles to your application.
+Additionally, the `config/locales/simple_form_tailwind.en.yml` file will add the "required" mark to the required fields.
+However, you need to communicate Tailwind to "watch" those files by adding the following configuration:
+
+```js
+# tailwind.config.js
+
+module.exports = {
+  ...
+  content: [
+    './config/initializers/simple_form_tailwindcss.rb',
+    './config/locales/simple_form*.yml',
+    ...
+  ],
+}
+```
+
+### Install Bulma CSS files
 
 ```bash
 bin/rails generate simple_form:theme:bulma install

--- a/lib/generators/simple_form/theme/tailwind/USAGE
+++ b/lib/generators/simple_form/theme/tailwind/USAGE
@@ -1,8 +1,6 @@
-Description:
-    Install the simple form tailwindcss config file in your app.
-
-Example:
+Install Command:
     bin/rails generate simple_form:theme:tailwind install
 
     This will create:
         config/initializers/simple_form_tailwindcss.rb
+        config/locales/

--- a/lib/generators/simple_form/theme/tailwind/tailwind_generator.rb
+++ b/lib/generators/simple_form/theme/tailwind/tailwind_generator.rb
@@ -3,8 +3,27 @@
 class SimpleForm::Theme::TailwindGenerator < Rails::Generators::NamedBase
   source_root File.expand_path('templates', __dir__)
 
-  desc 'Copy the tailwindcss initializer file for simple_form'
-  def copy_initializer_file
+  desc 'Copy the tailwindcss files for simple_form'
+  def generate
+    install if install?
+  end
+
+  private
+
+  def install
+    copy_initializers
+    copy_locales
+  end
+
+  def install?
+    name == 'install'
+  end
+
+  def copy_initializers
     template 'config/initializers/simple_form_tailwindcss.rb', 'config/initializers/simple_form_tailwindcss.rb'
+  end
+
+  def copy_locales
+    directory 'config/locales'
   end
 end

--- a/lib/generators/simple_form/theme/tailwind/templates/config/locales/simple_form_tailwind.en.yml
+++ b/lib/generators/simple_form/theme/tailwind/templates/config/locales/simple_form_tailwind.en.yml
@@ -1,0 +1,6 @@
+en:
+  simple_form:
+    required:
+      text: 'required'
+      mark: '*'
+      html: '<abbr class="text-red-500 no-underline" title="required">*</abbr>'

--- a/test/lib/generators/simple_form/theme/simple_form/theme/tailwind_generator_test.rb
+++ b/test/lib/generators/simple_form/theme/simple_form/theme/tailwind_generator_test.rb
@@ -11,8 +11,18 @@ module SimpleForm::Theme
 
     test 'generator runs without errors' do
       assert_nothing_raised do
-        run_generator ['install']
+        run_generator ['random']
       end
+    end
+
+    test 'generator copies the initializer file' do
+      run_generator ['install']
+      assert_file 'config/initializers/simple_form_tailwindcss.rb'
+    end
+
+    test 'generator copies the locales files' do
+      run_generator ['install']
+      assert_directory 'config/locales'
     end
   end
 end


### PR DESCRIPTION
This change is adding the required color to the required fields.

![image](https://github.com/JuanVqz/simple_form-theme/assets/7331511/c3a59f9a-4e6e-4d25-8c80-d72519380106)

Here is the [example](https://github.com/heartcombo/simple_form/pulls#discussion_r1314143816)

NOTE: `config/initializers/simple_form_tailwindcss.rb` and `config/locales/simple_form_tailwind.en.yml` must be included in the `tailwind.config.js` file as is described in the README
